### PR TITLE
feat(deployment): add GitHub Actions workflow for backend & frontend deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,69 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      # Step 2: Set up the Google Cloud SDK using the latest version (v2.1.4)
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2.1.4
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      # --- Backend Deployment ---
+      - name: Build Backend Docker Image
+        run: |
+          docker build -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/fastapi-backend:latest backend/
+
+      - name: Push Backend Docker Image
+        run: |
+          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/fastapi-backend:latest
+
+      - name: Deploy Backend to Cloud Run
+        id: deploy-backend
+        run: |
+          gcloud run deploy fastapi-backend \
+            --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/fastapi-backend:latest \
+            --region us-east4 \
+            --platform managed \
+            --allow-unauthenticated \
+            --max-instances=1 \
+            --set-env-vars SPOONACULAR_API_KEY=${{ secrets.SPOONACULAR_API_KEY }}
+
+      - name: Retrieve Backend Service URL
+        id: get_backend_url
+        run: |
+          SERVICE_URL=$(gcloud run services describe fastapi-backend --region us-east4 --platform managed --format='value(status.url)')
+          echo "Backend Service URL: ${SERVICE_URL}"
+          echo "service_url=${SERVICE_URL}" >> $GITHUB_OUTPUT
+
+      # --- Frontend Deployment ---
+      - name: Build Frontend Docker Image
+        run: |
+          docker build \
+            --build-arg VITE_BACKEND_URL=${{ steps.get_backend_url.outputs.service_url }} \
+            -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/vite-frontend:latest \
+            frontend/
+
+      - name: Push Frontend Docker Image
+        run: |
+          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/vite-frontend:latest
+
+      - name: Deploy Frontend to Cloud Run
+        run: |
+          gcloud run deploy vite-frontend \
+            --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/vite-frontend:latest \
+            --region us-east4 \
+            --platform managed \
+            --allow-unauthenticated \
+            --max-instances=1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,33 +1,18 @@
-# Use an official Python image
-FROM python:3.12.4
-
-# Accept build argument for version
-ARG VERSION=latest
-# Set version as a label
-LABEL version=$VERSION
-
-# Set environment variable in "KEY=VALUE" format
-ENV PYTHONUNBUFFERED=True
-
-# Create and use a directory for your app
+# Stage 1: Builder
+FROM python:3.12.4 AS builder
 WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 
-# Upgrade pip
-RUN pip install --upgrade pip
+# Stage 2: Final Image
+FROM python:3.12.4-slim
+WORKDIR /app
+# Copy application code from the builder stage
+COPY --from=builder /app /app
+# Reinstall dependencies in the final image
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy only the requirements file first (for faster caching of pip installs)
-COPY ./requirements.txt /app/requirements.txt
-
-# Install Python dependencies
-RUN pip install --no-cache-dir -r /app/requirements.txt
-
-# Copy the entire project into /app
-# This allows you to have backend, frontend, etc. all in one container
-COPY . /app
-
-# Expose the port (FastAPI default in your code is 8080)
 EXPOSE 8080
 
-# Run the FastAPI app with uvicorn
-# If "main.py" is inside "backend/" and defines `app = FastAPI()`, use "backend.main:app"
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
### Title
feat(deployment): add GitHub Actions workflow for backend & frontend deployment

### Summary
- Build and deploy FastAPI backend with SPOONACULAR_API_KEY env variable to Cloud Run (us-east4, max 1 instance)
- Retrieve backend URL and pass it as VITE_BACKEND_URL build argument for Vite frontend
- Build and deploy Vite frontend to Cloud Run

### Changes
- README.md
- .github/deploy.yaml
- backend/Dockerfile

### Additional Information
Make sure Github Repo has env variables already set for gcp and spoontacular api

### Checklist
- [x] Tested
- [x] Error Handling works
- [x] No console errors or warnings
- [x] Relevant documentation/comments are included
- [x] Code follows the project’s coding standards
